### PR TITLE
Update ball placement 

### DIFF
--- a/consai2_game/scripts/example/actions/ball_placement.py
+++ b/consai2_game/scripts/example/actions/ball_placement.py
@@ -18,7 +18,7 @@ from field import Field
 from observer import Observer
 
 # 後ろに周り込むときの位置取り
-SET_POSE_ADD_X = 0.3
+SET_POSE_ADD_X_ATK = 0.3
 SET_POSE_ADD_X_RECV = 0.1
 # kick_power
 KICK_POWER = 0.3
@@ -26,13 +26,11 @@ KICK_POWER = 0.3
 DRIBBLE_POWER = 0.6
 
 # ボールがplacementされたとみなされる範囲
+# 実際にボールがplacementされたとみなされる範囲は0.15[m]
 BALL_PLACE_TRESHOLD = 0.10
-# 実際にボールがplacementされたとみなされる範囲
-BALL_PLACE_AREA = 0.15
+# BALL_PLACE_AREA = 0.15
 # ボールを置きに行く動作に入るときの範囲(ドリブルしない）
 BALL_PLACE_AREA_NO_DRIBBLE = 0.3
-# ボールを置きに行く動作に入るときの範囲
-# BALL_PLACE_AREA = 0.5
 # ボールに近いと判断する距離
 BALL_GET_AREA = 4.0
 # ボールが動いていると判断する速度
@@ -93,7 +91,7 @@ def get_near_robot_id(target_pose, robot_info):
 
 # ball placementrを行う
 # atkとrecvの2台で行う
-def basic_ball_placement(control_target, target_pose, ball_info, robot_info, my_id, mode='atk'):
+def basic_ball_placement(control_target, target_pose, ball_info, robot_info, my_id, mode):
  
     # ペアになるロボットのID
     # target_poseに一番距離が一番近いロボットを使う
@@ -125,67 +123,57 @@ def basic_atk(control_target, ball_info, atk_pose, recv_pose, target_pose):
     # 目標位置はボールの前方にし、目標角度は、自己位置からみたボール方向にする
     trans = tool.Trans(ball_info.pose, angle_ball_to_target)
 
-    # 座標変換
-    tr_atk_pose = trans.transform(atk_pose)
-
     # ボールとpalcement位置の距離
     dist_ball_to_target = tool.distance_2_poses(ball_info.pose, target_pose)
 
-    # レシーブを行う座標を生成
+    # レシーブを行う座標
     target_back_pose = generate_target_back_pose(trans, target_pose, SET_POSE_ADD_X_RECV)
-
-    # recvとレシーブを行う座標との距離
-    dist_recv_to_target_back = tool.distance_2_poses(recv_pose, target_back_pose)
 
     # ボール速度
     ball_vel = ball_info.velocity
     v = math.hypot(ball_vel.x, ball_vel.y)
 
+    # ---------------------------------------
     # placementの行動生成
-    new_pose = Pose2D()
-    avoid_ball = False
 
-    # ボールが範囲に入っていない場合は処理を行う
+    # デフォルト値
+    avoid_ball = False
+    control_target.kick_power = 0.0
+    control_target.dribble_power = 0.0
+
+    new_pose = Pose2D()
+    # ボールが範囲に入っていない場合はplacementを行う
     if BALL_PLACE_TRESHOLD < dist_ball_to_target:
 
         # 指定位置に到着したかどうか
-        atk_flag = threshold_pose(tr_atk_pose)
-        recv_flag = threshold_dist(dist_recv_to_target_back)
+        atk_flag = threshold_pose(trans.transform(atk_pose))
+        recv_flag = threshold_dist(tool.distance_2_poses(recv_pose, target_back_pose))
         
-        # ---------------------------------------
         # 蹴ったあとにatkが追いかけない様に対策
         if VEL_THRESHOLD < v:
             new_pose = atk_pose
-            control_target.dribble_power = 0
-
-        elif (tr_atk_pose.y < -0.05 or 0.05 < tr_atk_pose.y) and 0.1 < dist_recv_to_target_back:
-            new_pose = trans.inverted_transform(Pose2D(-SET_POSE_ADD_X, 0, 0))
+        
+        # atkがボールの後ろにいなければ移動する
+        elif not atk_flag:
+            # ボールの後ろに座標を生成
+            new_pose = trans.inverted_transform(Pose2D(-SET_POSE_ADD_X_ATK, 0, 0))
             new_pose.theta = angle_ball_to_target
             
-            # ドリブルする
-            control_target.kick_power = 0.0
-            control_target.dribble_power = DRIBBLE_POWER
-
             avoid_ball = True
 
         # もしボールとゴールに近い場合はアタッカーが置きにいく
-        elif dist_ball_to_target < BALL_PLACE_AREA_NO_DRIBBLE:
-            # ドリブルする
-            control_target = offense.inplay_dribble(atk_pose, ball_info, 
-                    control_target, target_pose)
-            new_pose = control_target.path[-1]
-            control_target.dribble_power = 0.0
-
-        # もしボールとゴールに近い場合はアタッカーが置きにいく
-        # ボールを拾いに行く
         elif dist_ball_to_target < BALL_GET_AREA:
             
             # ドリブルする
             control_target = offense.inplay_dribble(atk_pose, ball_info, 
                     control_target,target_pose)
             new_pose = control_target.path[-1]
-            control_target.kick_power = 0.0
-            control_target.dribble_power = DRIBBLE_POWER
+           
+            # ドリブルをやめる範囲ならドリブル
+            control_target.dribble_power = 0.0
+            if BALL_PLACE_AREA_NO_DRIBBLE < dist_ball_to_target:
+                control_target.dribble_power = DRIBBLE_POWER
+
 
         # お互いの位置がセットされたら蹴る
         elif atk_flag and recv_flag:
@@ -201,12 +189,8 @@ def basic_atk(control_target, ball_info, atk_pose, recv_pose, target_pose):
         # ボールの後ろに移動
         else:
             # ボールの後ろに周り込む
-            new_pose = trans.inverted_transform(Pose2D(-SET_POSE_ADD_X, 0, 0))
+            new_pose = trans.inverted_transform(Pose2D(-SET_POSE_ADD_X_ATK, 0, 0))
             new_pose.theta = angle_ball_to_target
-
-            # ドリブルとキックをオフ
-            control_target.kick_power = 0.0
-            control_target.dribble_power = 0.0
 
             avoid_ball = True
 
@@ -217,10 +201,6 @@ def basic_atk(control_target, ball_info, atk_pose, recv_pose, target_pose):
         new_pose.x = target_pose.x + BALL_MARGIN_DIST * math.cos(angle_atk_to_target)
         new_pose.y = target_pose.y + BALL_MARGIN_DIST * math.sin(angle_atk_to_target)
         new_pose.theta = angle_atk_to_target + math.pi
-
-        # 引くだけなのでドリブラを切る
-        control_target.dribble_power = 0.0
-        control_target.kick_power = 0.0
 
     # パスを追加
     control_target.path = []
@@ -240,12 +220,6 @@ def basic_recv(control_target, ball_info, atk_pose, recv_pose, target_pose):
     # ボールとpalcement位置の距離
     dist_ball_to_target = tool.distance_2_poses(ball_info.pose, target_pose)
 
-    # レシーブを行う座標を生成
-    target_back_pose = generate_target_back_pose(trans, target_pose, SET_POSE_ADD_X_RECV)
-
-    # 座標変換
-    tr_target_back_pose = trans.transform(target_back_pose)
-
     # ボールの速度
     ball_vel = ball_info.velocity
     v = math.hypot(ball_vel.x, ball_vel.y)
@@ -253,8 +227,15 @@ def basic_recv(control_target, ball_info, atk_pose, recv_pose, target_pose):
     # 目標座標までの角度
     angle_ball_to_target = tool.get_angle(ball_info.pose, target_pose)
 
-    new_pose = Pose2D()
+    # ---------------------------------------
+    # placementの行動生成
+
+    # デフォルト値
     avoid_ball = True
+    control_target.kick_power = 0.0
+    control_target.dribble_power = 0.0
+
+    new_pose = Pose2D()
     if BALL_PLACE_TRESHOLD < dist_ball_to_target:
 
         # 速度が出ている場合レシーブしにいく
@@ -264,17 +245,12 @@ def basic_recv(control_target, ball_info, atk_pose, recv_pose, target_pose):
             new_pose = receive_ball(ball_info, recv_pose)
 
             # ドリブルする
-            control_target.kick_power = 0
             control_target.dribble_power = DRIBBLE_POWER
 
         # placement座標の少し後ろに移動する
         else:
-            new_pose = trans.inverted_transform(tr_target_back_pose)
+            new_pose = generate_target_back_pose(trans, target_pose, SET_POSE_ADD_X_RECV) 
             new_pose.theta = angle_ball_to_target + math.pi
-
-            # ドリブルとキックをオフ
-            control_target.kick_power = 0.0
-            control_target.dribble_power = 0.0
     else:
         # placement後に離れる
         angle_recv_to_target = tool.get_angle(target_pose, recv_pose)
@@ -291,19 +267,18 @@ def basic_recv(control_target, ball_info, atk_pose, recv_pose, target_pose):
     return control_target, avoid_ball
 
 # 配置を担当しないロボットは避ける
-def avoid_ball_place_line(my_pose, ball_info, placement_pose, control_target, force_avoid=False):
+def avoid_ball_place_line(my_pose, ball_info, target_pose, control_target, force_avoid=False):
 
-    angle_ball2placement = tool.get_angle(ball_info.pose, placement_pose)
-
-    trans = tool.Trans(ball_info.pose, angle_ball2placement)
+    # ボール中心に座標変換
+    angle_ball_to_target = tool.get_angle(ball_info.pose, target_pose)
+    trans = tool.Trans(ball_info.pose, angle_ball_to_target)
     tr_my_pose = trans.transform(my_pose)
-    tr_placement_pose = trans.transform(placement_pose)
-    dist_ball2placement = tool.distance_2_poses(ball_info.pose, placement_pose)
+    tr_target_pose = trans.transform(target_pose)
+    dist_ball_to_target = tool.distance_2_poses(ball_info.pose, target_pose)
 
-    # ライン上にいるやつは避ける
-    # if -BALL_MARGIN_DIST < tr_my_pose.x < tr_placement_pose.x + BALL_MARGIN_DIST and \
-        # -BALL_MARGIN_DIST < tr_my_pose.y < BALL_MARGIN_DIST:
-    if BALL_PLACE_AREA_NO_DRIBBLE < dist_ball2placement or force_avoid:
+    # ライン上にいるロボットは回避位置を生成する
+    # ラインに対して垂直に移動する
+    if BALL_PLACE_AREA_NO_DRIBBLE < dist_ball_to_target or force_avoid:
         if -BALL_MARGIN_DIST < tr_my_pose.y < BALL_MARGIN_DIST:
             if tr_my_pose.y < 0:
                 tr_my_pose.y -= BALL_MARGIN_DIST

--- a/consai2_game/scripts/example/game.py
+++ b/consai2_game/scripts/example/game.py
@@ -226,14 +226,8 @@ class RobotNode(object):
                     avoid_obstacle = False # 障害物回避しない
                 elif self._my_role == role.ROLE_ID["ROLE_ATTACKER"]:
                     self._control_target, avoid_ball = ball_placement.basic_ball_placement(self._control_target, replace_pose, ball_info, robot_info, self._MY_ID, mode='atk')
-                    # self._control_target, avoid_ball = ball_placement.atk(
-                            # self._my_pose, ball_info, self._control_target, replace_pose, \
-                            # robot_info, self._MY_ID)
                 elif self._my_role == role.ROLE_ID["ROLE_DEFENCE_GOAL_1"]:
                     self._control_target, avoid_ball = ball_placement.basic_ball_placement(self._control_target, replace_pose, ball_info, robot_info, self._MY_ID, mode='recv')
-                    # self._control_target, avoid_ball = ball_placement.recv(
-                            # self._my_pose, ball_info, self._control_target, replace_pose, \
-                            # role.ROLE_ID["ROLE_ATTACKER"], robot_info)
                 else:
                     self._control_target, avoid_ball = ball_placement.avoid_ball_place_line(
                             self._my_pose, ball_info, replace_pose, self._control_target)

--- a/consai2_game/scripts/example/game.py
+++ b/consai2_game/scripts/example/game.py
@@ -225,13 +225,15 @@ class RobotNode(object):
                             ball_info, robot_info, self._control_target)
                     avoid_obstacle = False # 障害物回避しない
                 elif self._my_role == role.ROLE_ID["ROLE_ATTACKER"]:
-                    self._control_target, avoid_ball = ball_placement.atk(
-                            self._my_pose, ball_info, self._control_target, replace_pose, \
-                            robot_info, self._MY_ID)
+                    self._control_target, avoid_ball = ball_placement.basic_ball_placement(self._control_target, replace_pose, ball_info, robot_info, self._MY_ID, mode='atk')
+                    # self._control_target, avoid_ball = ball_placement.atk(
+                            # self._my_pose, ball_info, self._control_target, replace_pose, \
+                            # robot_info, self._MY_ID)
                 elif self._my_role == role.ROLE_ID["ROLE_DEFENCE_GOAL_1"]:
-                    self._control_target, avoid_ball = ball_placement.recv(
-                            self._my_pose, ball_info, self._control_target, replace_pose, \
-                            role.ROLE_ID["ROLE_ATTACKER"], robot_info)
+                    self._control_target, avoid_ball = ball_placement.basic_ball_placement(self._control_target, replace_pose, ball_info, robot_info, self._MY_ID, mode='recv')
+                    # self._control_target, avoid_ball = ball_placement.recv(
+                            # self._my_pose, ball_info, self._control_target, replace_pose, \
+                            # role.ROLE_ID["ROLE_ATTACKER"], robot_info)
                 else:
                     self._control_target, avoid_ball = ball_placement.avoid_ball_place_line(
                             self._my_pose, ball_info, replace_pose, self._control_target)
@@ -429,7 +431,6 @@ class Game(object):
             self._roledecision.check_ball_dist([i.pose for i in self._robot_info['our']], self._ball_info)
         self._roledecision.event_observer()
         defense_num = self._roledecision._rolestocker._defence_num
-
 
         self._obstacle_avoidance.update_obstacles(self._ball_info, self._robot_info)
         for our_info in self._robot_info['our']:


### PR DESCRIPTION
#70 ball_placementのコード整理
- 冗長な表現の削除
- 関数にまとめた
- コメントの追加

変更にあたり、ball_placement.py側で関数名の変更を行ったため、game.pyも変更されています。具体的には以下の関数内でatkとrecvの関数を呼び出すように変更しています。modeを指定するだけでatkとrecvを分けています＆引数もかなりスッキリさせました

```
basic_ball_placement(control_target, target_pose, ball_info, robot_info, my_id, mode)
```

game.py変更前
```
elif self._my_role == role.ROLE_ID["ROLE_ATTACKER"]:
    self._control_target, avoid_ball = ball_placement.atk(
            self._my_pose, ball_info, self._control_target, replace_pose, \
            robot_info, self._MY_ID)
elif self._my_role == role.ROLE_ID["ROLE_DEFENCE_GOAL_1"]:
    self._control_target, avoid_ball = ball_placement.recv(
            self._my_pose, ball_info, self._control_target, replace_pose, \
            role.ROLE_ID["ROLE_ATTACKER"], robot_info)
```

game.py変更後

```
elif self._my_role == role.ROLE_ID["ROLE_ATTACKER"]:
    self._control_target, avoid_ball = ball_placement.basic_ball_placement(self._control_target, replace_pose, ball_info, robot_info, self._MY_ID, mode='atk')
elif self._my_role == role.ROLE_ID["ROLE_DEFENCE_GOAL_1"]:
    self._control_target, avoid_ball = ball_placement.basic_ball_placement(self._control_target, replace_pose, ball_info, robot_info, self._MY_ID, mode='recv')
```