### PR TITLE
一番ボールに近いロボ判断に使用するデータをlast_detection_poseからposeに変更

### DIFF
--- a/consai2_game/scripts/example/role.py
+++ b/consai2_game/scripts/example/role.py
@@ -63,9 +63,9 @@ class RoleDecision(object):
             if self._robot_disappeared[robot_id] == False and \
                     robot_id != self._GOALIE_ID:
                 # ロボットとボールの距離を計算
-                # ボールが消える可能性を考慮して、last_detection_poseを使う
+                # もともとlast_detection_poseを使用していたが、不要と思われるのでposeにした
                 dist = tool.distance_2_poses(our_pose[robot_id], 
-                        ball_info.last_detection_pose)
+                        ball_info.pose)
                 # 距離の更新
                 self._dist_to_ball[robot_id] = dist
 


### PR DESCRIPTION
ボールが一番近いロボットの切り替わり判断に
last_detection_poseを使っていたが
ボールがワープしたときのroleの切り替わりがおかしいのでposeに修正。
もともとlast_detection_poseにしていたのは、ボールの予測が入る前に開発していた名残と思われる。