### PR TITLE
Mft2020 update pk joywrapper

### DIFF
--- a/consai2_examples/README.md
+++ b/consai2_examples/README.md
@@ -179,6 +179,11 @@ MakerFaireTokyo 2020で実施したデモプログラムです。
 
 1 vs 1のPKを行います。
 
+ジョイコントローラが必要です。下記のコントローラに対応しています。
+
+- [Logicool Wireless Gamepad F710](https://gaming.logicool.co.jp/ja-jp/products/gamepads/f710-wireless-gamepad.html#940-0001440)
+- [SONY DUALSHOCK 3](https://www.jp.playstation.com/ps3/peripheral/cechzc2j.html)
+
 次のコマンドでノードを起動します。
 
 ```sh
@@ -187,4 +192,42 @@ $ roslaunch consai2_examples pk_example.launch sim:=true side:=left
 
 # 例：実機で、右から左に攻める
 $ roslaunch consai2_examples pk_example.launch sim:=false side:=right
+
+# 例：シミュレータ上で、/dev/input/js0に接続されたDUALSHOCK3コントローラを使う
+$ roslaunch consai2_examples pk_example.launch sim:=true joydev:=/dev/input/js0 joyconfig:=dualshock3
+
+# 例：実機で、/dev/input/js1に接続されたF710コントローラを使う
+$ roslaunch consai2_examples pk_example.launch sim:=false joydev:=/dev/input/js1 joyconfig:=f710
 ```
+
+### KeyConfig
+
+かざすセンサ、フットスイッチ
+
+|Key combination|Function|
+|:---|:---|
+|`L stick ↑↓←→`| kazasu_left (0.0 ~ 1.0) の生成|
+|`R stick ↑↓←→`| kazasu_right (0.0 ~ 1.0) の生成|
+|`L1`| foot_switch (Bool) の生成|
+
+アタッカー
+
+|Key combination|Function|
+|:---|:---|
+|`START`| 動作停止 |
+|`R2` + `START`| 動作開始/停止の切り替え|
+|`R2` + `D-Pad ↑↓`|IDの変更 (0 ~ `max_id`)|
+|`R2` + `D-Pad →`|チームカラーの切り替え (blue or yellow)|
+|`○`|かざすセンサ、フットスイッチを**使用しない**|
+|`R2` + `○`|かざすセンサ、フットスイッチ使用/未使用の切り替え|
+
+キーパー
+
+|Key combination|Function|
+|:---|:---|
+|`SELECT`| 動作停止 |
+|`L2` + `SELECT`| 動作開始/停止の切り替え|
+|`L2` + `D-Pad ↑↓`|IDの変更 (0 ~ `max_id`)|
+|`L2` + `D-Pad →`|チームカラーの切り替え (blue or yellow)|
+|`□`|かざすセンサ、フットスイッチを**使用しない**|
+|`L2` + `□`|かざすセンサ、フットスイッチ使用/未使用の切り替え|

--- a/consai2_examples/launch/pk_example.launch
+++ b/consai2_examples/launch/pk_example.launch
@@ -3,6 +3,7 @@
   <arg name="side" default="left" />
   <arg name="sim" default="false" />
   <arg name="joydev" default="/dev/input/js0" />
+  <arg name="joyconfig" default="dualshock3" />
 
   <node name="joy_core" pkg="joy" type="joy_node" required="true">
     <param name="dev" type="string" value="$(arg joydev)" />
@@ -18,7 +19,9 @@
   <node name="vision_wrapper" pkg="consai2_world_observer" type="consai2_world_observer" required="true" output="screen" />
   <node name="consai2_visualizer" pkg="consai2_gui" type="consai2_gui" required="true" output="screen" />
 
-  <node name="pk_example" pkg="consai2_examples" type="pk_example.py" required="true" output="screen" />
+  <node name="pk_example" pkg="consai2_examples" type="pk_example.py" required="true" output="screen">
+    <rosparam command="load" file="$(find consai2_examples)/param/pk_joy_$(arg joyconfig).yaml" />
+  </node>
 
   <node name="consai2_control" pkg="consai2_control" type="example_control.py" required="true" output="screen" />
   <include file="$(find consai2_sender)/launch/sender.launch">

--- a/consai2_examples/param/pk_joy_dualshock3.yaml
+++ b/consai2_examples/param/pk_joy_dualshock3.yaml
@@ -4,12 +4,12 @@ axis_kazasu_left_y : 1
 axis_kazasu_right_x : 3
 axis_kazasu_right_y : 4
 
-button_attacker_enable : 7
-button_goalie_enable : 6
+button_attacker_config_enable : 7
+button_goalie_config_enable : 6
 button_attacker_can_move : 9
 button_goalie_can_move : 8
-
-button_can_use_kazasu_foot : 1
+button_attacker_kazafoo_available : 1
+button_goalie_kazafoo_available : 3
 
 analog_d_pad            : false
 d_pad_up                : 13

--- a/consai2_examples/param/pk_joy_dualshock3.yaml
+++ b/consai2_examples/param/pk_joy_dualshock3.yaml
@@ -1,0 +1,25 @@
+button_foot_switch : 4
+axis_kazasu_left_x : 0
+axis_kazasu_left_y : 1
+axis_kazasu_right_x : 3
+axis_kazasu_right_y : 4
+
+button_attacker_enable : 7
+button_goalie_enable : 6
+button_attacker_can_move : 9
+button_goalie_can_move : 8
+
+button_can_use_kazasu_foot : 1
+
+analog_d_pad            : false
+d_pad_up                : 13
+d_pad_down              : 14
+d_pad_left              : 15
+d_pad_right             : 16
+# for analog_d_pad 
+d_pad_up_is_positive    : true
+d_pad_right_is_positive : false
+
+d_pad_id_increment : "up"
+d_pad_id_decrement : "down"
+d_pad_color_toggle : "right"

--- a/consai2_examples/param/pk_joy_f710.yaml
+++ b/consai2_examples/param/pk_joy_f710.yaml
@@ -1,0 +1,25 @@
+button_foot_switch : 4
+axis_kazasu_left_x : 0
+axis_kazasu_left_y : 1
+axis_kazasu_right_x : 2
+axis_kazasu_right_y : 3
+
+button_attacker_config_enable : 7
+button_goalie_config_enable : 6
+button_attacker_can_move : 9
+button_goalie_can_move : 8
+button_attacker_kazafoo_available : 2
+button_goalie_kazafoo_available : 0
+
+analog_d_pad            : true
+d_pad_up                : 5
+d_pad_down              : 5
+d_pad_left              : 4
+d_pad_right             : 4
+# for analog_d_pad 
+d_pad_up_is_positive    : true
+d_pad_right_is_positive : false
+
+d_pad_id_increment : "up"
+d_pad_id_decrement : "down"
+d_pad_color_toggle : "right"

--- a/consai2_examples/scripts/pk_example.py
+++ b/consai2_examples/scripts/pk_example.py
@@ -143,6 +143,10 @@ def main():
             attacker_kazasu_right = joy_wrapper.get_kazasu_right()
             attacker_foot_switch_has_pressed = joy_wrapper.get_foot_switch_has_pressed()
 
+        # # デバッグ用なので後で消すこと
+        # print("attacker:" + str(joy_wrapper.get_attacker_can_use_kazasu_foot())
+        #     + ", goalie:" + str(joy_wrapper.get_goalie_can_use_kazasu_foot()))
+
         # ゴーリー、アタッカーの位置情報を取得
         goalie_info = get_robot_info(goalie_id, goalie_is_yellow)
         attacker_info = get_robot_info(attacker_id, attacker_is_yellow)

--- a/consai2_examples/scripts/pk_joy_wrapper.py
+++ b/consai2_examples/scripts/pk_joy_wrapper.py
@@ -1,8 +1,10 @@
 
+import rospy
 from sensor_msgs.msg import Joy
 
 class JoyWrapper(object):
     def __init__(self):
+        rospy.loginfo(rospy.get_param('~button_foot_switch'))
         pass
 
     def update(self, joy_msg):

--- a/consai2_examples/scripts/pk_joy_wrapper.py
+++ b/consai2_examples/scripts/pk_joy_wrapper.py
@@ -1,44 +1,305 @@
+# coding: UTF-8
 
+import math
 import rospy
 from sensor_msgs.msg import Joy
 
 class JoyWrapper(object):
     def __init__(self):
-        rospy.loginfo(rospy.get_param('~button_foot_switch'))
-        pass
+        self._MAX_ID = rospy.get_param('consai2_description/max_id', 10)
+
+        self._BUTTON_FOOT_SWITCH = rospy.get_param('~button_foot_switch')
+        self._AXIS_KAZASU_LEFT_X = rospy.get_param('~axis_kazasu_left_x')
+        self._AXIS_KAZASU_LEFT_Y = rospy.get_param('~axis_kazasu_left_y')
+        self._AXIS_KAZASU_RIGHT_X = rospy.get_param('~axis_kazasu_right_x')
+        self._AXIS_KAZASU_RIGHT_Y = rospy.get_param('~axis_kazasu_right_y')
+
+        self._BUTTON_ATTACKER_CONFIG_ENABLE = rospy.get_param('~button_attacker_config_enable')
+        self._BUTTON_GOALIE_CONFIG_ENABLE = rospy.get_param('~button_goalie_config_enable')
+        self._BUTTON_ATTACKER_CAN_MOVE = rospy.get_param('~button_attacker_can_move')
+        self._BUTTON_GOALIE_CAN_MOVE = rospy.get_param('~button_goalie_can_move')
+        self._BUTTON_ATTACKER_KAZAFOO_AVAILABLE = rospy.get_param('~button_attacker_kazafoo_available')
+        self._BUTTON_GOALIE_KAZAFOO_AVAILABLE = rospy.get_param('~button_goalie_kazafoo_available')
+
+        self._ANALOG_D_PAD = rospy.get_param('~analog_d_pad')
+        self._D_PAD_UP = rospy.get_param('~d_pad_up')
+        self._D_PAD_DOWN = rospy.get_param('~d_pad_down')
+        self._D_PAD_LEFT = rospy.get_param('~d_pad_left')
+        self._D_PAD_RIGHT = rospy.get_param('~d_pad_right')
+        self._D_PAD_UP_IS_POSITIVE = rospy.get_param('~d_pad_up_is_positive')
+        self._D_PAD_RIGHT_IS_POSITIVE = rospy.get_param('~d_pad_right_is_positive')
+
+        self._D_PAD_ID_INCREMENT = rospy.get_param('~d_pad_id_increment')
+        self._D_PAD_ID_DECREMENT = rospy.get_param('~d_pad_id_decrement')
+        self._D_PAD_COLOR_TOGGLE = rospy.get_param('~d_pad_color_toggle')
+
+        self._foot_switch_has_pressed = False
+        self._kazasu_left = 0.0
+        self._kazasu_right = 0.0
+        self._attacker_can_move = False
+        self._goalie_can_move = False
+        self._attacker_id = 0
+        self._goalie_id = 0
+        self._attacker_is_yellow = False
+        self._goalie_is_yellow = True
+        self._attacker_kazafoo_is_available = False
+        self._goalie_kazafoo_is_available = False
+
+        self._attacker_move_state_is_changing = False
+        self._attacker_id_is_changing = False
+        self._attacker_color_is_changing = False
+        self._goalie_move_state_is_changing = False
+        self._goalie_id_is_changing = False
+        self._goalie_color_is_changing = False
+        self._attacker_kazafoo_availability_is_changing = False
+        self._goalie_kazafoo_availability_is_changing = False
 
     def update(self, joy_msg):
-        pass
+        if not joy_msg.buttons or not joy_msg.axes:
+            rospy.logwarn("ジョイコンのメッセージが来てないよ")
+            return
+
+        if joy_msg.buttons[self._BUTTON_FOOT_SWITCH]:
+            self._foot_switch_has_pressed = True
+        else:
+            self._foot_switch_has_pressed = False
+
+        # アナログスティックをどこに傾けても、0.0 ~ 1.0を得る
+        self._kazasu_left = max(
+            math.fabs(joy_msg.axes[self._AXIS_KAZASU_LEFT_X]),
+            math.fabs(joy_msg.axes[self._AXIS_KAZASU_LEFT_Y]),
+            )
+        self._kazasu_right = max(
+            math.fabs(joy_msg.axes[self._AXIS_KAZASU_RIGHT_X]),
+            math.fabs(joy_msg.axes[self._AXIS_KAZASU_RIGHT_Y]),
+            )
+
+        state_has_changed = False
+        state_has_changed |= self._change_attacker_move_state(joy_msg)
+        state_has_changed |= self._change_goalie_move_state(joy_msg)
+        state_has_changed |= self._change_attacker_id(joy_msg)
+        state_has_changed |= self._change_goalie_id(joy_msg)
+        state_has_changed |= self._toggle_attacker_color(joy_msg)
+        state_has_changed |= self._toggle_goalie_color(joy_msg)
+        state_has_changed |= self._change_attacker_kazafoo_availability(joy_msg)
+        state_has_changed |= self._change_goalie_kazafoo_availability(joy_msg)
+
+        # デバッグ用のメッセージ（本番運用でもメッセージを出力したほうが作業しやすい）
+        if state_has_changed:
+            text =  "attacker(Yellow:" + str(self._attacker_is_yellow) \
+                + "\tID:" + str(self._attacker_id) \
+                + "\tMove:" + str(self._attacker_can_move) \
+                + "\tKazafoo:" + str(self._attacker_kazafoo_is_available) \
+                + ")attacker\n" \
+                + "goalie(Yellow:" + str(self._goalie_is_yellow) \
+                + "\tID:" + str(self._goalie_id) \
+                + "\tMove:" + str(self._goalie_can_move) \
+                + "\tKazafoo:" + str(self._goalie_kazafoo_is_available) \
+                + ")goalie"
+            print(text)
 
     def get_attacker_id(self):
-        return 1
+        return self._attacker_id
 
     def get_attacker_is_yellow(self):
-        return False
+        return self._attacker_is_yellow
 
     def get_goalie_id(self):
-        return 0
+        return self._goalie_id
     
     def get_goalie_is_yellow(self):
-        return False
+        return self._goalie_is_yellow
 
     def get_kazasu_left(self):
-        return 0.0
+        return self._kazasu_left
 
     def get_kazasu_right(self):
-        return 0.0
+        return self._kazasu_right
 
     def get_foot_switch_has_pressed(self):
-        return False
+        return self._foot_switch_has_pressed
 
     def get_attacker_can_move(self):
-        return True
+        return self._attacker_can_move
 
     def get_goalie_can_move(self):
-        return True
+        return self._goalie_can_move
 
     def get_attacker_can_use_kazasu_foot(self):
-        return False
+        return self._attacker_kazafoo_is_available
 
     def get_goalie_can_use_kazasu_foot(self):
-        return False
+        return self._goalie_kazafoo_is_available
+
+    def _change_attacker_move_state(self, joy_msg):
+        state_has_changed = False
+        if joy_msg.buttons[self._BUTTON_ATTACKER_CAN_MOVE]:
+            if joy_msg.buttons[self._BUTTON_ATTACKER_CONFIG_ENABLE]:
+                if not self._attacker_move_state_is_changing:
+                    self._attacker_can_move = not self._attacker_can_move
+                    self._attacker_move_state_is_changing = True
+                    state_has_changed = True
+            else:
+                # Enableが押されていないときはロボットを停止する
+                self._attacker_can_move = False
+                state_has_changed = True
+        else:
+            self._attacker_move_state_is_changing = False
+
+        return state_has_changed
+
+    def _change_goalie_move_state(self, joy_msg):
+        state_has_changed = False
+        if joy_msg.buttons[self._BUTTON_GOALIE_CAN_MOVE]:
+            if joy_msg.buttons[self._BUTTON_GOALIE_CONFIG_ENABLE]:
+                if not self._goalie_move_state_is_changing:
+                    self._goalie_can_move = not self._goalie_can_move
+                    self._goalie_move_state_is_changing = True
+                    state_has_changed = True
+            else:
+                # Enableが押されていないときはロボットを停止する
+                self._goalie_can_move = False
+                state_has_changed = True
+        else:
+            self._goalie_move_state_is_changing = False
+        
+        return state_has_changed
+
+    def _change_attacker_id(self, joy_msg):
+        state_has_changed = False
+        if joy_msg.buttons[self._BUTTON_ATTACKER_CONFIG_ENABLE]:
+            if self._d_pad(joy_msg, self._D_PAD_ID_INCREMENT):
+                if self._attacker_id < self._MAX_ID \
+                    and not self._attacker_id_is_changing:
+                    self._attacker_id += 1
+                    self._attacker_id_is_changing = True
+                    state_has_changed = True
+
+            elif self._d_pad(joy_msg, self._D_PAD_ID_DECREMENT):
+                if self._attacker_id > 0 \
+                    and not self._attacker_id_is_changing:
+                    self._attacker_id -= 1
+                    self._attacker_id_is_changing = True
+                    state_has_changed = True
+
+            else:
+                self._attacker_id_is_changing = False
+
+        return state_has_changed
+
+    def _change_goalie_id(self, joy_msg):
+        state_has_changed = False
+        if joy_msg.buttons[self._BUTTON_GOALIE_CONFIG_ENABLE]:
+            if self._d_pad(joy_msg, self._D_PAD_ID_INCREMENT):
+                if self._goalie_id < self._MAX_ID \
+                    and not self._goalie_id_is_changing:
+                    self._goalie_id += 1
+                    self._goalie_id_is_changing = True
+                    state_has_changed = True
+
+            elif self._d_pad(joy_msg, self._D_PAD_ID_DECREMENT):
+                if self._goalie_id > 0 \
+                    and not self._goalie_id_is_changing:
+                    self._goalie_id -= 1
+                    self._goalie_id_is_changing = True
+                    state_has_changed = True
+
+            else:
+                self._goalie_id_is_changing = False
+
+        return state_has_changed
+
+    def _toggle_attacker_color(self, joy_msg):
+        state_has_changed = False
+        if joy_msg.buttons[self._BUTTON_ATTACKER_CONFIG_ENABLE]:
+            if self._d_pad(joy_msg, self._D_PAD_COLOR_TOGGLE):
+                if not self._attacker_color_is_changing:
+                    self._attacker_is_yellow = not self._attacker_is_yellow
+                    self._attacker_color_is_changing = True
+                    state_has_changed = True
+            else:
+                self._attacker_color_is_changing = False
+        
+        return state_has_changed
+
+    def _toggle_goalie_color(self, joy_msg):
+        state_has_changed = False
+        if joy_msg.buttons[self._BUTTON_GOALIE_CONFIG_ENABLE]:
+            if self._d_pad(joy_msg, self._D_PAD_COLOR_TOGGLE):
+                if not self._goalie_color_is_changing:
+                    self._goalie_is_yellow = not self._goalie_is_yellow
+                    self._goalie_color_is_changing = True
+                    state_has_changed = True
+            else:
+                self._goalie_color_is_changing = False
+
+        return state_has_changed
+
+    def _change_attacker_kazafoo_availability(self, joy_msg):
+        state_has_changed = False
+        if joy_msg.buttons[self._BUTTON_ATTACKER_KAZAFOO_AVAILABLE]:
+            if joy_msg.buttons[self._BUTTON_ATTACKER_CONFIG_ENABLE]:
+                if not self._attacker_kazafoo_availability_is_changing:
+                    self._attacker_kazafoo_is_available = not self._attacker_kazafoo_is_available
+                    self._attacker_kazafoo_availability_is_changing = True
+                    state_has_changed = True
+            else:
+                self._attacker_kazafoo_is_available = False
+                state_has_changed = True
+        else:
+            self._attacker_kazafoo_availability_is_changing = False
+
+        return state_has_changed
+
+    def _change_goalie_kazafoo_availability(self, joy_msg):
+        state_has_changed = False
+        if joy_msg.buttons[self._BUTTON_GOALIE_KAZAFOO_AVAILABLE]:
+            if joy_msg.buttons[self._BUTTON_GOALIE_CONFIG_ENABLE]:
+                if not self._goalie_kazafoo_availability_is_changing:
+                    self._goalie_kazafoo_is_available = not self._goalie_kazafoo_is_available
+                    self._goalie_kazafoo_availability_is_changing = True
+                    state_has_changed = True
+            else:
+                self._goalie_kazafoo_is_available = False
+                state_has_changed = True
+        else:
+            self._goalie_kazafoo_availability_is_changing = False
+        
+        return state_has_changed
+
+    def _joy_d_pad(self, joy_msg, target_pad, positive_on):
+        if self._ANALOG_D_PAD:
+            if positive_on:
+                return joy_msg.axes[target_pad] > 0
+            else:
+                return joy_msg.axes[target_pad] < 0
+        else:
+            return joy_msg.buttons[target_pad]
+
+    def _d_pad_up(self, joy_msg):
+        positive_on = self._D_PAD_UP_IS_POSITIVE
+        return self._joy_d_pad(joy_msg, self._D_PAD_UP, positive_on)
+
+    def _d_pad_down(self, joy_msg):
+        positive_on = not self._D_PAD_UP_IS_POSITIVE
+        return self._joy_d_pad(joy_msg, self._D_PAD_DOWN, positive_on)
+
+    def _d_pad_left(self, joy_msg):
+        positive_on = not self._D_PAD_RIGHT_IS_POSITIVE
+        return self._joy_d_pad(joy_msg, self._D_PAD_LEFT, positive_on)
+
+    def _d_pad_right(self, joy_msg):
+        positive_on = self._D_PAD_RIGHT_IS_POSITIVE
+        return self._joy_d_pad(joy_msg, self._D_PAD_RIGHT, positive_on)
+
+    def _d_pad(self, joy_msg, target):
+        if target == "up":
+            return self._d_pad_up(joy_msg)
+        elif target == "down":
+            return self._d_pad_down(joy_msg)
+        elif target == "left":
+            return self._d_pad_left(joy_msg)
+        elif target == "right":
+            return self._d_pad_right(joy_msg)
+        else:
+            return False


### PR DESCRIPTION
MFT 2020のデモにジョイコントローラのラッパーを実装しました。

- [x] Kazasu & Foot Switchの信号生成や、ゴーリー＆アタッカーのID、カラー変更等の基本機能
- [x] SONY DUALSHOCK 3コントローラ対応
- [x] Logicool F710 コントローラ対応
- [x] キー割り当てをconsai2_examplesのREADMEに記載

