### PR TITLE
Merge kazafoo node

### DIFF
--- a/consai2_control/scripts/example/example_control.py
+++ b/consai2_control/scripts/example/example_control.py
@@ -99,7 +99,7 @@ class Controller(object):
         self._PID_GAIN = { # 位置制御のPIDゲイン
                 "x":PIDGain(1.475, 0.0, 21.0),
                 "y":PIDGain(1.475, 0.0, 21.0),
-                "theta":PIDGain(1.0, 0.0, 0.0)
+                "theta":PIDGain(1.2, 0.0, 10.0)
                 }
 
         self._MAX_ID = rospy.get_param('consai2_description/max_id', 15)

--- a/consai2_examples/README.md
+++ b/consai2_examples/README.md
@@ -187,6 +187,9 @@ MakerFaireTokyo 2020で実施したデモプログラムです。
 次のコマンドでノードを起動します。
 
 ```sh
+# 例：実機で、kazafoo装置を使う
+$ roslaunch consai2_examples pk_example.launch sim:=false use_kazafoo:=true
+
 # 例：シミュレータ上で、左から右に攻める
 $ roslaunch consai2_examples pk_example.launch sim:=true side:=left
 

--- a/consai2_examples/launch/pk_example.launch
+++ b/consai2_examples/launch/pk_example.launch
@@ -4,6 +4,7 @@
   <arg name="sim" default="false" />
   <arg name="joydev" default="/dev/input/js0" />
   <arg name="joyconfig" default="dualshock3" />
+  <arg name="use_kazafoo" default="false" />
 
   <node name="joy_core" pkg="joy" type="joy_node" required="true">
     <param name="dev" type="string" value="$(arg joydev)" />
@@ -22,6 +23,10 @@
   <node name="pk_example" pkg="consai2_examples" type="pk_example.py" required="true" output="screen">
     <rosparam command="load" file="$(find consai2_examples)/param/pk_joy_$(arg joyconfig).yaml" />
   </node>
+
+  <group if="$(arg use_kazafoo)">
+    <node name="kazafoo_node" pkg="consai2_kazafoo" type="kazafoo.py" required="true" output="screen" />
+  </group>
 
   <node name="consai2_control" pkg="consai2_control" type="example_control.py" required="true" output="screen" />
   <include file="$(find consai2_sender)/launch/sender.launch">

--- a/consai2_examples/scripts/pk_attacker.py
+++ b/consai2_examples/scripts/pk_attacker.py
@@ -15,12 +15,12 @@ class PkAttacker(object):
 
     def __init__(self, rostime_now):
         # ボールに近づいた時、近づけたかを判定するしきい値。小さいほどきびしい
-        self._APPROACH_DIST = 0.1  # meters
+        self._APPROACH_DIST = 0.12  # meters
         # ボールに近づいた時、ボールを見ているか判定するしきい値。小さいほどきびしい
-        self._APPROACH_ANGLE = 10.0  # degrees
+        self._APPROACH_ANGLE = 5.0  # degrees
         # ボールまわりで旋回する時、ターゲット（ゴール）を見ているか判定するしきい値
         # 小さいほどきびしい
-        self._LOOK_TARGET_ANGLE = 10.0  # degrees
+        self._LOOK_TARGET_ANGLE = 5.0  # degrees
 
         # フットスイッチ長押し時に、キックフラグをリセットする時間
         # 5 をセットすると、5秒に１回キックフラグをFalseにする
@@ -30,7 +30,7 @@ class PkAttacker(object):
         self._DRIBBLE_POWER = 1.0  # 0.0 ~ 1.0
         self._KICK_POWER = 0.5  # 0.0 ~ 1.0
         # kazasuで操作するときの角速度
-        self._AIM_OMEGA = 0.1  # rad/sec
+        self._AIM_OMEGA = 0.8  # rad/sec
         # kazasuで操作するときの、前進速度。
         self._AIM_VEL = 0.05  # meter/sec
 

--- a/consai2_examples/scripts/pk_attacker.py
+++ b/consai2_examples/scripts/pk_attacker.py
@@ -15,9 +15,9 @@ class PkAttacker(object):
 
     def __init__(self, rostime_now):
         # ボールに近づいた時、近づけたかを判定するしきい値。小さいほどきびしい
-        self._APPROACH_DIST = 0.2  # meters
+        self._APPROACH_DIST = 0.1  # meters
         # ボールに近づいた時、ボールを見ているか判定するしきい値。小さいほどきびしい
-        self._APPROACH_ANGLE = 15.0  # degrees
+        self._APPROACH_ANGLE = 10.0  # degrees
         # ボールまわりで旋回する時、ターゲット（ゴール）を見ているか判定するしきい値
         # 小さいほどきびしい
         self._LOOK_TARGET_ANGLE = 10.0  # degrees
@@ -27,12 +27,12 @@ class PkAttacker(object):
         self._KICK_FLAG_RESET_TIME = 5  # seconds
 
         # 旋回時、シュート時のドリブルパワー
-        self._DRIBBLE_POWER = 0.6  # 0.0 ~ 1.0
-        self._KICK_POWER = 1.0  # 0.0 ~ 1.0
+        self._DRIBBLE_POWER = 1.0  # 0.0 ~ 1.0
+        self._KICK_POWER = 0.5  # 0.0 ~ 1.0
         # kazasuで操作するときの角速度
-        self._AIM_OMEGA = 0.5  # rad/sec
+        self._AIM_OMEGA = 0.1  # rad/sec
         # kazasuで操作するときの、前進速度。
-        self._AIM_VEL = 0.1  # meter/sec
+        self._AIM_VEL = 0.05  # meter/sec
 
         self._kick_timestamp = rostime_now
         self._current_state = self._STATE_DISAPPEARED


### PR DESCRIPTION
- consai2_controlの回転制御のPIDゲインを更新します
- READMEに`use_kazafoo`オプションの説明を追記します
- launchファイルでkazafoo ノードを起動します
  - `use_kazafoo`オプションの追加
- アタッカーのパラメータを更新します
- `pk_example`が`joy_kazafoo`トピックをサブスクライブします
- ゴーリーに渡す`goal_width`を1.0 mで固定します
  - SSL-Visionでゴール座標の設定が難しかったため
- 実機ロボットが正常動作しない不具合を修正します
  - 停止すべきロボットに`control_enable=True`を送ってました

